### PR TITLE
Add some flexibility to account for more use cases:

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -57,7 +57,7 @@ if [ -z "$bitrise_tag_format" ]; then
     printf -v TAG_NAME "v%s(%s)" "$CFBundleShortVersionString" "$CFBundleVersion"
 else
     name="${bitrise_tag_format//_VERSION_/$CFBundleShortVersionString}"
-    name="${name//_BUILD_/$CFBundleShortVersionString}"
+    name="${name//_BUILD_/$CFBundleVersion}"
     printf -v TAG_NAME "$name"
 fi
 echo $TAG_NAME

--- a/step.sh
+++ b/step.sh
@@ -10,7 +10,7 @@ CFBundleVersion=""
 CFBundleVersionKey=false
 
 CFBundleShortVersionString=""
-CFBundleShortVersionStringKey=false   
+CFBundleShortVersionStringKey=false
 
 if [ -z "$bitrise_tag_info_plist_path" ]; then
     echo "bitrise_tag_info_plist_path is empty"
@@ -18,14 +18,14 @@ if [ -z "$bitrise_tag_info_plist_path" ]; then
 fi
 
 while read_dom; do
-	if [[ $CFBundleShortVersionStringKey = true ]]; then 
+	if [[ $CFBundleShortVersionStringKey = true ]]; then
 		if [ $ENTITY = "string" ] ; then
 		    CFBundleShortVersionString=$CONTENT
 	    	CFBundleShortVersionStringKey=false
 		fi
     fi
-    
-    if [[ $CFBundleVersionKey = true ]]; then 
+
+    if [[ $CFBundleVersionKey = true ]]; then
 		if [ $ENTITY = "string" ] ; then
 		    CFBundleVersion=$CONTENT
 	    	CFBundleVersionKey=false
@@ -35,7 +35,7 @@ while read_dom; do
     if [[ $CONTENT = "CFBundleShortVersionString" ]] ; then
     	CFBundleShortVersionStringKey=true
     fi
-    
+
     if [[ $CONTENT = "CFBundleVersion" ]] ; then
     	CFBundleVersionKey=true
     fi
@@ -54,14 +54,21 @@ fi
 TAG_NAME=""
 
 if [ -z "$bitrise_tag_format" ]; then
-	printf -v TAG_NAME "v%s(%s)" "$CFBundleShortVersionString" "$CFBundleVersion"
+    printf -v TAG_NAME "v%s(%s)" "$CFBundleShortVersionString" "$CFBundleVersion"
 else
-	printf -v TAG_NAME "$bitrise_tag_format" "$CFBundleShortVersionString" "$CFBundleVersion"
+    name="${bitrise_tag_format//_VERSION_/$CFBundleShortVersionString}"
+    name="${name//_BUILD_/$CFBundleShortVersionString}"
+    printf -v TAG_NAME "$name"
 fi
 echo $TAG_NAME
 git checkout "$BITRISE_GIT_BRANCH"
-git tag "$TAG_NAME"
-git push --tags
+git tag "$TAG_NAME" "$GIT_CLONE_COMMIT_HASH"
+
+if [[ $use_lightweight_tag = "yes" ]]; then
+    git push origin "$TAG_NAME"
+else
+    git push --tags
+fi
 
 exit 0
 

--- a/step.yml
+++ b/step.yml
@@ -72,13 +72,22 @@ inputs:
       description: |
         File of your release 'Info.plist' file
       is_required: true
-  - bitrise_tag_format: "v%s(%s)"
+  - bitrise_tag_format: "v_VERSION_(_BUILD_)"
     opts:
       title: "Result format"
       summary: Provide format of generated tag & build number
       description: |
-        Provide format of generated tag & build number
+        Provide format of generated tag & build number. You can use the following placeholders: ``_VERSION_``, ``_BUILD_``
       is_required: false
+  - use_lightweight_tag: "no"
+    opts:
+      category: Config
+      title: "Use lightweight tag?"
+      description: |
+        If yes, the tag will be lightweight, i.e. not trigger a commit/push
+      value_options:
+        - "no"
+        - "yes"
 
 outputs:
   - EXAMPLE_STEP_OUTPUT:


### PR DESCRIPTION
 - add lightweight-tag toggle as config option
 - rework tag format to make use of placeholders for version and build number
 - fix bug: now always tag the current codebase instead of HEAD