### PR TITLE
Update tag to latest commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ _tmp/test_config/Test.xcodeproj/project.xcworkspace
 _tmp/test_info_plist/Test.xcodeproj/project.xcworkspace
 _tmp/test_info_plist/Test.xcodeproj/xcuserdata
 _tmp/test_config/Test.xcodeproj/xcuserdata
+_tmp/test_workspace_config/Test.xcodeproj/project.xcworkspace
+_tmp/test_workspace_config/Test.xcodeproj/xcuserdata
+_tmp/test_workspace_config/Test.xcworkspace/xcuserdata
+_tmp/test_workspace_config/Test.xcworkspace/xcshareddata

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ _tmp/test_workspace_config/Test.xcodeproj/project.xcworkspace
 _tmp/test_workspace_config/Test.xcodeproj/xcuserdata
 _tmp/test_workspace_config/Test.xcworkspace/xcuserdata
 _tmp/test_workspace_config/Test.xcworkspace/xcshareddata
+Info.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 .bitrise*
 .gows.user.yml
+_tmp/test_build_settings/Test.xcodeproj/project.xcworkspace
+_tmp/test_build_settings/Test.xcodeproj/xcuserdata
+_tmp/test_config/Test.xcodeproj/project.xcworkspace
+_tmp/test_info_plist/Test.xcodeproj/project.xcworkspace
+_tmp/test_info_plist/Test.xcodeproj/xcuserdata
+_tmp/test_config/Test.xcodeproj/xcuserdata

--- a/_tmp/test_build_settings/Test.xcodeproj/project.pbxproj
+++ b/_tmp/test_build_settings/Test.xcodeproj/project.pbxproj
@@ -1,0 +1,335 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E1F267A715900E65CC0 /* TestApp.swift */; };
+		9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E21267A715900E65CC0 /* ContentView.swift */; };
+		9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E23267A715A00E65CC0 /* Assets.xcassets */; };
+		9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9A9A9E1C267A715900E65CC0 /* Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Test.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A9A9E1F267A715900E65CC0 /* TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		9A9A9E21267A715900E65CC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9A9A9E23267A715A00E65CC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9A9A9E28267A715A00E65CC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9A9A9E19267A715900E65CC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9A9A9E13267A715900E65CC0 = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1E267A715900E65CC0 /* Test */,
+				9A9A9E1D267A715900E65CC0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A9A9E1D267A715900E65CC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1C267A715900E65CC0 /* Test.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9A9A9E1E267A715900E65CC0 /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1F267A715900E65CC0 /* TestApp.swift */,
+				9A9A9E21267A715900E65CC0 /* ContentView.swift */,
+				9A9A9E23267A715A00E65CC0 /* Assets.xcassets */,
+				9A9A9E28267A715A00E65CC0 /* Info.plist */,
+				9A9A9E25267A715A00E65CC0 /* Preview Content */,
+			);
+			path = Test;
+			sourceTree = "<group>";
+		};
+		9A9A9E25267A715A00E65CC0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A9A9E1B267A715900E65CC0 /* Test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */;
+			buildPhases = (
+				9A9A9E18267A715900E65CC0 /* Sources */,
+				9A9A9E19267A715900E65CC0 /* Frameworks */,
+				9A9A9E1A267A715900E65CC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Test;
+			productName = Test;
+			productReference = 9A9A9E1C267A715900E65CC0 /* Test.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A9A9E14267A715900E65CC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					9A9A9E1B267A715900E65CC0 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9A9A9E13267A715900E65CC0;
+			productRefGroup = 9A9A9E1D267A715900E65CC0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A9A9E1B267A715900E65CC0 /* Test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9A9A9E1A267A715900E65CC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */,
+				9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9A9A9E18267A715900E65CC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */,
+				9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9A9A9E29267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9A9A9E2A267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9A9A9E2C267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A9A9E2D267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E29267A715A00E65CC0 /* Debug */,
+				9A9A9E2A267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E2C267A715A00E65CC0 /* Debug */,
+				9A9A9E2D267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9A9A9E14267A715900E65CC0 /* Project object */;
+}

--- a/_tmp/test_build_settings/Test/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/_tmp/test_build_settings/Test/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_build_settings/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/_tmp/test_build_settings/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_build_settings/Test/Assets.xcassets/Contents.json
+++ b/_tmp/test_build_settings/Test/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_build_settings/Test/ContentView.swift
+++ b/_tmp/test_build_settings/Test/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/_tmp/test_build_settings/Test/Info.plist
+++ b/_tmp/test_build_settings/Test/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/_tmp/test_build_settings/Test/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/_tmp/test_build_settings/Test/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_build_settings/Test/TestApp.swift
+++ b/_tmp/test_build_settings/Test/TestApp.swift
@@ -1,0 +1,17 @@
+//
+//  TestApp.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+@main
+struct TestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/_tmp/test_config/Test.xcodeproj/project.pbxproj
+++ b/_tmp/test_config/Test.xcodeproj/project.pbxproj
@@ -1,0 +1,343 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E1F267A715900E65CC0 /* TestApp.swift */; };
+		9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E21267A715900E65CC0 /* ContentView.swift */; };
+		9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E23267A715A00E65CC0 /* Assets.xcassets */; };
+		9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */; };
+		9A9A9E2F267A772C00E65CC0 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9A9A9E1C267A715900E65CC0 /* Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Test.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A9A9E1F267A715900E65CC0 /* TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		9A9A9E21267A715900E65CC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9A9A9E23267A715A00E65CC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9A9A9E28267A715A00E65CC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9A9A9E19267A715900E65CC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9A9A9E13267A715900E65CC0 = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1E267A715900E65CC0 /* Test */,
+				9A9A9E1D267A715900E65CC0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A9A9E1D267A715900E65CC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1C267A715900E65CC0 /* Test.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9A9A9E1E267A715900E65CC0 /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1F267A715900E65CC0 /* TestApp.swift */,
+				9A9A9E21267A715900E65CC0 /* ContentView.swift */,
+				9A9A9E23267A715A00E65CC0 /* Assets.xcassets */,
+				9A9A9E28267A715A00E65CC0 /* Info.plist */,
+				9A9A9E25267A715A00E65CC0 /* Preview Content */,
+				9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */,
+			);
+			path = Test;
+			sourceTree = "<group>";
+		};
+		9A9A9E25267A715A00E65CC0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A9A9E1B267A715900E65CC0 /* Test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */;
+			buildPhases = (
+				9A9A9E18267A715900E65CC0 /* Sources */,
+				9A9A9E19267A715900E65CC0 /* Frameworks */,
+				9A9A9E1A267A715900E65CC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Test;
+			productName = Test;
+			productReference = 9A9A9E1C267A715900E65CC0 /* Test.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A9A9E14267A715900E65CC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					9A9A9E1B267A715900E65CC0 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9A9A9E13267A715900E65CC0;
+			productRefGroup = 9A9A9E1D267A715900E65CC0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A9A9E1B267A715900E65CC0 /* Test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9A9A9E1A267A715900E65CC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */,
+				9A9A9E2F267A772C00E65CC0 /* Config.xcconfig in Resources */,
+				9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9A9A9E18267A715900E65CC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */,
+				9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9A9A9E29267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(MY_CURRENT_PROJECT_VERSION)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9A9A9E2A267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(MY_CURRENT_PROJECT_VERSION)";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9A9A9E2C267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A9A9E2D267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E29267A715A00E65CC0 /* Debug */,
+				9A9A9E2A267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E2C267A715A00E65CC0 /* Debug */,
+				9A9A9E2D267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9A9A9E14267A715900E65CC0 /* Project object */;
+}

--- a/_tmp/test_config/Test/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/_tmp/test_config/Test/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_config/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/_tmp/test_config/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_config/Test/Assets.xcassets/Contents.json
+++ b/_tmp/test_config/Test/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_config/Test/Config.xcconfig
+++ b/_tmp/test_config/Test/Config.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Config.xcconfig
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MY_MARKETING_VERSION = 1.0
+MY_CURRENT_PROJECT_VERSION = 1

--- a/_tmp/test_config/Test/ContentView.swift
+++ b/_tmp/test_config/Test/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/_tmp/test_config/Test/Info.plist
+++ b/_tmp/test_config/Test/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/_tmp/test_config/Test/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/_tmp/test_config/Test/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_config/Test/TestApp.swift
+++ b/_tmp/test_config/Test/TestApp.swift
@@ -1,0 +1,17 @@
+//
+//  TestApp.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+@main
+struct TestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/_tmp/test_info_plist/Test.xcodeproj/project.pbxproj
+++ b/_tmp/test_info_plist/Test.xcodeproj/project.pbxproj
@@ -1,0 +1,331 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E1F267A715900E65CC0 /* TestApp.swift */; };
+		9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E21267A715900E65CC0 /* ContentView.swift */; };
+		9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E23267A715A00E65CC0 /* Assets.xcassets */; };
+		9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9A9A9E1C267A715900E65CC0 /* Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Test.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A9A9E1F267A715900E65CC0 /* TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		9A9A9E21267A715900E65CC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9A9A9E23267A715A00E65CC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9A9A9E28267A715A00E65CC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9A9A9E19267A715900E65CC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9A9A9E13267A715900E65CC0 = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1E267A715900E65CC0 /* Test */,
+				9A9A9E1D267A715900E65CC0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A9A9E1D267A715900E65CC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1C267A715900E65CC0 /* Test.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9A9A9E1E267A715900E65CC0 /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1F267A715900E65CC0 /* TestApp.swift */,
+				9A9A9E21267A715900E65CC0 /* ContentView.swift */,
+				9A9A9E23267A715A00E65CC0 /* Assets.xcassets */,
+				9A9A9E28267A715A00E65CC0 /* Info.plist */,
+				9A9A9E25267A715A00E65CC0 /* Preview Content */,
+			);
+			path = Test;
+			sourceTree = "<group>";
+		};
+		9A9A9E25267A715A00E65CC0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A9A9E1B267A715900E65CC0 /* Test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */;
+			buildPhases = (
+				9A9A9E18267A715900E65CC0 /* Sources */,
+				9A9A9E19267A715900E65CC0 /* Frameworks */,
+				9A9A9E1A267A715900E65CC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Test;
+			productName = Test;
+			productReference = 9A9A9E1C267A715900E65CC0 /* Test.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A9A9E14267A715900E65CC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					9A9A9E1B267A715900E65CC0 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9A9A9E13267A715900E65CC0;
+			productRefGroup = 9A9A9E1D267A715900E65CC0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A9A9E1B267A715900E65CC0 /* Test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9A9A9E1A267A715900E65CC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */,
+				9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9A9A9E18267A715900E65CC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */,
+				9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9A9A9E29267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9A9A9E2A267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9A9A9E2C267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A9A9E2D267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E29267A715A00E65CC0 /* Debug */,
+				9A9A9E2A267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E2C267A715A00E65CC0 /* Debug */,
+				9A9A9E2D267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9A9A9E14267A715900E65CC0 /* Project object */;
+}

--- a/_tmp/test_info_plist/Test/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/_tmp/test_info_plist/Test/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_info_plist/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/_tmp/test_info_plist/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_info_plist/Test/Assets.xcassets/Contents.json
+++ b/_tmp/test_info_plist/Test/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_info_plist/Test/ContentView.swift
+++ b/_tmp/test_info_plist/Test/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/_tmp/test_info_plist/Test/Info.plist
+++ b/_tmp/test_info_plist/Test/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/_tmp/test_info_plist/Test/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/_tmp/test_info_plist/Test/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_info_plist/Test/TestApp.swift
+++ b/_tmp/test_info_plist/Test/TestApp.swift
@@ -1,0 +1,17 @@
+//
+//  TestApp.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+@main
+struct TestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/_tmp/test_workspace_config/Test.xcodeproj/project.pbxproj
+++ b/_tmp/test_workspace_config/Test.xcodeproj/project.pbxproj
@@ -1,0 +1,343 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E1F267A715900E65CC0 /* TestApp.swift */; };
+		9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A9A9E21267A715900E65CC0 /* ContentView.swift */; };
+		9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E23267A715A00E65CC0 /* Assets.xcassets */; };
+		9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */; };
+		9A9A9E2F267A772C00E65CC0 /* Config.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		9A9A9E1C267A715900E65CC0 /* Test.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Test.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		9A9A9E1F267A715900E65CC0 /* TestApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestApp.swift; sourceTree = "<group>"; };
+		9A9A9E21267A715900E65CC0 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		9A9A9E23267A715A00E65CC0 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		9A9A9E28267A715A00E65CC0 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		9A9A9E19267A715900E65CC0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		9A9A9E13267A715900E65CC0 = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1E267A715900E65CC0 /* Test */,
+				9A9A9E1D267A715900E65CC0 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		9A9A9E1D267A715900E65CC0 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1C267A715900E65CC0 /* Test.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		9A9A9E1E267A715900E65CC0 /* Test */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E1F267A715900E65CC0 /* TestApp.swift */,
+				9A9A9E21267A715900E65CC0 /* ContentView.swift */,
+				9A9A9E23267A715A00E65CC0 /* Assets.xcassets */,
+				9A9A9E28267A715A00E65CC0 /* Info.plist */,
+				9A9A9E25267A715A00E65CC0 /* Preview Content */,
+				9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */,
+			);
+			path = Test;
+			sourceTree = "<group>";
+		};
+		9A9A9E25267A715A00E65CC0 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				9A9A9E26267A715A00E65CC0 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		9A9A9E1B267A715900E65CC0 /* Test */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */;
+			buildPhases = (
+				9A9A9E18267A715900E65CC0 /* Sources */,
+				9A9A9E19267A715900E65CC0 /* Frameworks */,
+				9A9A9E1A267A715900E65CC0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Test;
+			productName = Test;
+			productReference = 9A9A9E1C267A715900E65CC0 /* Test.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		9A9A9E14267A715900E65CC0 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1250;
+				LastUpgradeCheck = 1250;
+				TargetAttributes = {
+					9A9A9E1B267A715900E65CC0 = {
+						CreatedOnToolsVersion = 12.5;
+					};
+				};
+			};
+			buildConfigurationList = 9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 9A9A9E13267A715900E65CC0;
+			productRefGroup = 9A9A9E1D267A715900E65CC0 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				9A9A9E1B267A715900E65CC0 /* Test */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		9A9A9E1A267A715900E65CC0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E27267A715A00E65CC0 /* Preview Assets.xcassets in Resources */,
+				9A9A9E2F267A772C00E65CC0 /* Config.xcconfig in Resources */,
+				9A9A9E24267A715A00E65CC0 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		9A9A9E18267A715900E65CC0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9A9A9E22267A715900E65CC0 /* ContentView.swift in Sources */,
+				9A9A9E20267A715900E65CC0 /* TestApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		9A9A9E29267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(MY_CURRENT_PROJECT_VERSION)";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		9A9A9E2A267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9A9A9E2E267A746C00E65CC0 /* Config.xcconfig */;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = "$(MY_CURRENT_PROJECT_VERSION)";
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		9A9A9E2C267A715A00E65CC0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		9A9A9E2D267A715A00E65CC0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"Test/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = Test/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = "$(MY_MARKETING_VERSION)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bitrise.test.Test;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		9A9A9E17267A715900E65CC0 /* Build configuration list for PBXProject "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E29267A715A00E65CC0 /* Debug */,
+				9A9A9E2A267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		9A9A9E2B267A715A00E65CC0 /* Build configuration list for PBXNativeTarget "Test" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9A9A9E2C267A715A00E65CC0 /* Debug */,
+				9A9A9E2D267A715A00E65CC0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 9A9A9E14267A715900E65CC0 /* Project object */;
+}

--- a/_tmp/test_workspace_config/Test.xcodeproj/xcshareddata/xcschemes/Test.xcscheme
+++ b/_tmp/test_workspace_config/Test.xcodeproj/xcshareddata/xcschemes/Test.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1250"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9A9A9E1B267A715900E65CC0"
+               BuildableName = "Test.app"
+               BlueprintName = "Test"
+               ReferencedContainer = "container:Test.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9A9A9E1B267A715900E65CC0"
+            BuildableName = "Test.app"
+            BlueprintName = "Test"
+            ReferencedContainer = "container:Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9A9A9E1B267A715900E65CC0"
+            BuildableName = "Test.app"
+            BlueprintName = "Test"
+            ReferencedContainer = "container:Test.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/_tmp/test_workspace_config/Test.xcworkspace/contents.xcworkspacedata
+++ b/_tmp/test_workspace_config/Test.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:Test.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/_tmp/test_workspace_config/Test/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/_tmp/test_workspace_config/Test/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_workspace_config/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/_tmp/test_workspace_config/Test/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_workspace_config/Test/Assets.xcassets/Contents.json
+++ b/_tmp/test_workspace_config/Test/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_workspace_config/Test/Config.xcconfig
+++ b/_tmp/test_workspace_config/Test/Config.xcconfig
@@ -1,0 +1,12 @@
+//
+//  Config.xcconfig
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+MY_MARKETING_VERSION = 1.0
+MY_CURRENT_PROJECT_VERSION = 1

--- a/_tmp/test_workspace_config/Test/ContentView.swift
+++ b/_tmp/test_workspace_config/Test/ContentView.swift
@@ -1,0 +1,21 @@
+//
+//  ContentView.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, world!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/_tmp/test_workspace_config/Test/Info.plist
+++ b/_tmp/test_workspace_config/Test/Info.plist
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/_tmp/test_workspace_config/Test/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/_tmp/test_workspace_config/Test/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/_tmp/test_workspace_config/Test/TestApp.swift
+++ b/_tmp/test_workspace_config/Test/TestApp.swift
@@ -1,0 +1,17 @@
+//
+//  TestApp.swift
+//  Test
+//
+//  Created by Denys Meloshyn on 16/06/2021.
+//
+
+import SwiftUI
+
+@main
+struct TestApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,6 +48,7 @@ workflows:
             #- bitrise_tag_format: "build__BUILD_"
             #- bitrise_tag_format: "v_VERSION_"
             - use_lightweight_tag: "no"
+            - update_tag: "no"
       - script:
           inputs:
             - content: |

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -29,7 +29,7 @@ workflows:
             but would break if the step is included in another `bitrise.yml`.
           run_if: true
           inputs:
-            - path: ./
+            - path: ./_tmp
             - is_create_path: true
       - path::./:
           title: Step Test
@@ -40,9 +40,9 @@ workflows:
             file if you would not specify another value.
           run_if: true
           inputs:
-            - bitrise_tag_xcodeproj_path: "./_tmp/Test.xcodeproj"
+            - bitrise_tag_xcodeproj_path: "./Test.xcodeproj"
             #- bitrise_tag_info_plist_path: "Info.plist"
-            - bitrise_tag_info_plist_path: "./_tmp/Info space name.plist"
+            - bitrise_tag_info_plist_path: "./Info space name.plist"
             #- bitrise_tag_info_plist_path: "Info_xcode_11.plist"
             - bitrise_tag_format: "v_VERSION_(_BUILD_)"
             #- bitrise_tag_format: "build__BUILD_"

--- a/read_bundle_version.py
+++ b/read_bundle_version.py
@@ -76,3 +76,20 @@ def read_short_bundle_version(info_plist_path, xcode_path, xcworkspace_path, sch
                                     xcworkspace_path=xcworkspace_path,
                                     scheme=scheme,
                                     config=config)
+
+
+def format_result(input_format, bundle_version, short_version):
+    if input_format is None:
+        return "v{}({})".format(short_version, bundle_version)
+
+    if input_format.find('_VERSION_') >= 0 or input_format.find('_BUILD_') >= 0:
+        if input_format.find('_VERSION_') >= 0 and input_format.find('_BUILD_') >= 0:
+            return input_format.replace('_VERSION_', short_version).replace('_BUILD_', bundle_version)
+        else:
+            if input_format.find('_VERSION_') >= 0:
+                return input_format.replace('_VERSION_', short_version)
+            else:
+                return input_format.replace('_BUILD_', bundle_version)
+    else:
+        # Support previous integration
+        return "v{}({})".format(short_version, bundle_version)

--- a/read_bundle_version.py
+++ b/read_bundle_version.py
@@ -57,34 +57,22 @@ def read_from_plist_or_xcode(plist_key, xcode_key, info_plist_path, xcode_path, 
 
     return value
 
-# read_from_plist_or_xcode(
-#     plist_key='CFBundleVersion',
-#     xcode_key='MARKETING_VERSION',
-#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-#                     '/test_info_plist/Test/Info.plist',
-#     xcode_path=None,
-#     xcworkspace_path=None,
-#     scheme=None,
-#     config=None)
-#
-# read_from_plist_or_xcode(
-#     plist_key='CFBundleVersion',
-#     xcode_key='MARKETING_VERSION',
-#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-#                     '/test_build_settings/Test/Info.plist',
-#     xcode_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-#                '/test_build_settings/Test.xcodeproj',
-#     xcworkspace_path=None,
-#     scheme=None,
-#     config=None)
-#
-# read_from_plist_or_xcode(
-#     plist_key='CFBundleVersion',
-#     xcode_key='MARKETING_VERSION',
-#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-#                     '/test_workspace_config/Test/Info.plist',
-#     xcode_path=None,
-#     xcworkspace_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-#                      '/test_workspace_config/Test.xcworkspace',
-#     scheme='Test',
-#     config='Config')
+
+def read_bundle_version(info_plist_path, xcode_path, xcworkspace_path, scheme, config):
+    return read_from_plist_or_xcode(plist_key='CFBundleVersion',
+                                    xcode_key='CURRENT_PROJECT_VERSION',
+                                    info_plist_path=info_plist_path,
+                                    xcode_path=xcode_path,
+                                    xcworkspace_path=xcworkspace_path,
+                                    scheme=scheme,
+                                    config=config)
+
+
+def read_short_bundle_version(info_plist_path, xcode_path, xcworkspace_path, scheme, config):
+    return read_from_plist_or_xcode(plist_key='CFBundleShortVersionString',
+                                    xcode_key='MARKETING_VERSION',
+                                    info_plist_path=info_plist_path,
+                                    xcode_path=xcode_path,
+                                    xcworkspace_path=xcworkspace_path,
+                                    scheme=scheme,
+                                    config=config)

--- a/read_bundle_version.py
+++ b/read_bundle_version.py
@@ -1,0 +1,87 @@
+import json
+import os
+
+
+def read_plist_value(key, info_plist_path):
+    os.system("plutil -convert json {} -e json".format(info_plist_path))
+
+    info_plist_json_path = info_plist_path.replace(".plist", ".json")
+    with open(info_plist_json_path, "r") as f:
+        data = json.load(f)
+
+    return data[key]
+
+
+def read_xcode_value(key, xcode_path, xcworkspace_path, scheme, config):
+    if xcode_path is not None:
+        stream = os.popen("xcodebuild -project {} -showBuildSettings -json".format(xcode_path))
+    elif xcworkspace_path is not None:
+        commands = [
+            "xcodebuild",
+            "-workspace {}".format(xcworkspace_path),
+            "-scheme {}".format(scheme),
+        ]
+
+        if config is not None:
+            commands += [
+                "-configuration {}".format(config)
+            ]
+
+        commands += [
+            "-showBuildSettings",
+            "-json"
+        ]
+
+        command = ' '.join(commands)
+        print(command)
+        stream = os.popen(command)
+    else:
+        exit("Path is not provided")
+
+    xcode_dict = json.loads(stream.read())
+    xcode_dict = xcode_dict[0]
+
+    return xcode_dict['buildSettings'][key]
+
+
+def read_from_plist_or_xcode(info_plist_path, xcode_path, xcworkspace_path, scheme, config):
+    os.system("plutil -convert json {} -e json".format(info_plist_path))
+
+    value = read_plist_value(key='CFBundleVersion', info_plist_path=info_plist_path)
+
+    if value.startswith('$('):
+        value = read_xcode_value(key='MARKETING_VERSION',
+                                 xcode_path=xcode_path,
+                                 xcworkspace_path=xcworkspace_path,
+                                 scheme=scheme,
+                                 config=config)
+
+    print(value)
+    return value
+
+
+read_from_plist_or_xcode(
+    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+                    '/test_info_plist/Test/Info.plist',
+    xcode_path=None,
+    xcworkspace_path=None,
+    scheme=None,
+    config=None)
+
+read_from_plist_or_xcode(
+    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+                    '/test_build_settings/Test/Info.plist',
+    xcode_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+               '/test_build_settings/Test.xcodeproj',
+    xcworkspace_path=None,
+    scheme=None,
+    config=None)
+
+read_from_plist_or_xcode(
+    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+                    '/test_workspace_config/Test/Info.plist',
+    xcode_path=None,
+    xcworkspace_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+                     '/test_workspace_config/Test.xcworkspace',
+    scheme='Test',
+    config='Config')

--- a/read_bundle_version.py
+++ b/read_bundle_version.py
@@ -33,7 +33,6 @@ def read_xcode_value(key, xcode_path, xcworkspace_path, scheme, config):
         ]
 
         command = ' '.join(commands)
-        print(command)
         stream = os.popen(command)
     else:
         exit("Path is not provided")
@@ -44,44 +43,48 @@ def read_xcode_value(key, xcode_path, xcworkspace_path, scheme, config):
     return xcode_dict['buildSettings'][key]
 
 
-def read_from_plist_or_xcode(info_plist_path, xcode_path, xcworkspace_path, scheme, config):
+def read_from_plist_or_xcode(plist_key, xcode_key, info_plist_path, xcode_path, xcworkspace_path, scheme, config):
     os.system("plutil -convert json {} -e json".format(info_plist_path))
 
-    value = read_plist_value(key='CFBundleVersion', info_plist_path=info_plist_path)
+    value = read_plist_value(key=plist_key, info_plist_path=info_plist_path)
 
     if value.startswith('$('):
-        value = read_xcode_value(key='MARKETING_VERSION',
+        value = read_xcode_value(key=xcode_key,
                                  xcode_path=xcode_path,
                                  xcworkspace_path=xcworkspace_path,
                                  scheme=scheme,
                                  config=config)
 
-    print(value)
     return value
 
-
-read_from_plist_or_xcode(
-    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-                    '/test_info_plist/Test/Info.plist',
-    xcode_path=None,
-    xcworkspace_path=None,
-    scheme=None,
-    config=None)
-
-read_from_plist_or_xcode(
-    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-                    '/test_build_settings/Test/Info.plist',
-    xcode_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-               '/test_build_settings/Test.xcodeproj',
-    xcworkspace_path=None,
-    scheme=None,
-    config=None)
-
-read_from_plist_or_xcode(
-    info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-                    '/test_workspace_config/Test/Info.plist',
-    xcode_path=None,
-    xcworkspace_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
-                     '/test_workspace_config/Test.xcworkspace',
-    scheme='Test',
-    config='Config')
+# read_from_plist_or_xcode(
+#     plist_key='CFBundleVersion',
+#     xcode_key='MARKETING_VERSION',
+#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+#                     '/test_info_plist/Test/Info.plist',
+#     xcode_path=None,
+#     xcworkspace_path=None,
+#     scheme=None,
+#     config=None)
+#
+# read_from_plist_or_xcode(
+#     plist_key='CFBundleVersion',
+#     xcode_key='MARKETING_VERSION',
+#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+#                     '/test_build_settings/Test/Info.plist',
+#     xcode_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+#                '/test_build_settings/Test.xcodeproj',
+#     xcworkspace_path=None,
+#     scheme=None,
+#     config=None)
+#
+# read_from_plist_or_xcode(
+#     plist_key='CFBundleVersion',
+#     xcode_key='MARKETING_VERSION',
+#     info_plist_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+#                     '/test_workspace_config/Test/Info.plist',
+#     xcode_path=None,
+#     xcworkspace_path='/Users/denys/Projects/bitrise-step-git-tag-project-version-and-build-number/_tmp'
+#                      '/test_workspace_config/Test.xcworkspace',
+#     scheme='Test',
+#     config='Config')

--- a/read_bundle_version.sh
+++ b/read_bundle_version.sh
@@ -12,8 +12,9 @@ function readBundleVersion() {
 	local __resultvar=$3
 
 	local bundle_version_result=""
+	local THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 	
-	source ./read_plist_bundle_version.sh readBundleVersion "$INFO_PLIST_PATH" bundle_version_result
+	source $THIS_SCRIPT_DIR/read_plist_bundle_version.sh readBundleVersion "$INFO_PLIST_PATH" bundle_version_result
 	if [ -z "$bundle_version_result" ]; then
   		echo "Plist CFBundleVersion is empty"
   		exit 1

--- a/read_short_bundle_version.sh
+++ b/read_short_bundle_version.sh
@@ -13,7 +13,7 @@ function readShortBundleVersion() {
 
 	local short_bundle_version_result=""
 	
-	source ./read_plist_short_bundle_version.sh readShortBundleVersion "$INFO_PLIST_PATH" short_bundle_version_result
+	source $THIS_SCRIPT_DIR/read_plist_short_bundle_version.sh readShortBundleVersion "$INFO_PLIST_PATH" short_bundle_version_result
 	if [ -z "$short_bundle_version_result" ]; then
 		echo "Plist CFBundleShortVersionString is empty"
 		exit 1

--- a/step.sh
+++ b/step.sh
@@ -6,19 +6,22 @@ if [ -z "$bitrise_tag_info_plist_path" ]; then
   exit 1
 fi
 
-source ./read_bundle_version.sh readBundleVersion "$bitrise_tag_info_plist_path" "$bitrise_tag_xcodeproj_path" CFBundleVersion
+# Copied from https://github.com/kawaiseb/bitrise-step-wetransfer/blob/master/step.sh
+THIS_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $THIS_SCRIPT_DIR/read_bundle_version.sh readBundleVersion "$bitrise_tag_info_plist_path" "$bitrise_tag_xcodeproj_path" CFBundleVersion
 if [ -z "$CFBundleVersion" ]; then
   echo "CFBundleVersion is empty"
   exit 1
 fi
 
-source ./read_short_bundle_version.sh readShortBundleVersion "$bitrise_tag_info_plist_path" "$bitrise_tag_xcodeproj_path" CFBundleShortVersionString
+source $THIS_SCRIPT_DIR/read_short_bundle_version.sh readShortBundleVersion "$bitrise_tag_info_plist_path" "$bitrise_tag_xcodeproj_path" CFBundleShortVersionString
 if [ -z "$CFBundleShortVersionString" ]; then
   echo "CFBundleShortVersionString is empty"
   exit 1
 fi
 
-source ./format_version_build.sh format $bitrise_tag_format $CFBundleVersion $CFBundleShortVersionString TAG_NAME
+source $THIS_SCRIPT_DIR/format_version_build.sh format $bitrise_tag_format $CFBundleVersion $CFBundleShortVersionString TAG_NAME
 echo "New tag: $TAG_NAME"
 
 git tag "$TAG_NAME" "$GIT_CLONE_COMMIT_HASH"

--- a/step.sh
+++ b/step.sh
@@ -24,6 +24,11 @@ fi
 source $THIS_SCRIPT_DIR/format_version_build.sh format $bitrise_tag_format $CFBundleVersion $CFBundleShortVersionString TAG_NAME
 echo "New tag: $TAG_NAME"
 
+if [[ $update_tag == "yes" && $(git tag -l "$TAG_NAME") ]]; then
+  git tag -d "$TAG_NAME"
+  git push --delete origin "$TAG_NAME"
+fi
+
 git tag "$TAG_NAME" "$GIT_CLONE_COMMIT_HASH"
 
 if [[ $use_lightweight_tag == "yes" ]]; then

--- a/step.yml
+++ b/step.yml
@@ -92,6 +92,15 @@ inputs:
       value_options:
         - "no"
         - "yes"
+  - update_tag: "no"
+    opts:
+      category: Config
+      title: "Update tag if already exists?"
+      description: |
+        If yes, the previous tag will be removed and recreated with the latest commit
+      value_options:
+        - "no"
+        - "yes"
 
 outputs:
   - EXAMPLE_STEP_OUTPUT:

--- a/test_read_from_plist_or_xcode.py
+++ b/test_read_from_plist_or_xcode.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from read_bundle_version import read_short_bundle_version
+from read_bundle_version import read_short_bundle_version, format_result
 
 
 class Test(TestCase):
@@ -39,3 +39,20 @@ class Test(TestCase):
             scheme='Test',
             config='Config')
         self.assertEqual(result, "1.0")
+
+    def test_no_input_format(self):
+        self.assertEqual(format_result(input_format=None, bundle_version='1', short_version='1.0'), 'v1.0(1)')
+
+    def test_legacy_format(self):
+        self.assertEqual(format_result(input_format='v%s(%s)', bundle_version='1', short_version='1.0'), 'v1.0(1)')
+
+    def test_both_input_format_parameters_exist(self):
+        self.assertEqual(format_result(input_format='v_VERSION_(_BUILD_)', bundle_version='1', short_version='1.0'),
+                         'v1.0(1)')
+
+    def test_version_input_format_parameter_exist(self):
+        self.assertEqual(format_result(input_format='v_VERSION_', bundle_version='1', short_version='1.0'),
+                         'v1.0')
+
+    def test_build_input_format_parameter_exist(self):
+        self.assertEqual(format_result(input_format='_BUILD_', bundle_version='1', short_version='1.0'), '1')

--- a/test_read_from_plist_or_xcode.py
+++ b/test_read_from_plist_or_xcode.py
@@ -1,24 +1,20 @@
 from unittest import TestCase
 
-from read_bundle_version import read_from_plist_or_xcode
+from read_bundle_version import read_short_bundle_version
 
 
 class Test(TestCase):
     def test_read_from_plist(self):
-        result = read_from_plist_or_xcode(
-            plist_key='CFBundleVersion',
-            xcode_key=None,
+        result = read_short_bundle_version(
             info_plist_path='./_tmp/test_info_plist/Test/Info.plist',
             xcode_path=None,
             xcworkspace_path=None,
             scheme=None,
             config=None)
-        self.assertEqual(result, "1")
+        self.assertEqual(result, "1.0")
 
     def test_read_from_xcode_build_settings(self):
-        result = read_from_plist_or_xcode(
-            plist_key='CFBundleVersion',
-            xcode_key='MARKETING_VERSION',
+        result = read_short_bundle_version(
             info_plist_path='./_tmp/test_build_settings/Test/Info.plist',
             xcode_path='./_tmp/test_build_settings/Test.xcodeproj',
             xcworkspace_path=None,
@@ -27,23 +23,19 @@ class Test(TestCase):
         self.assertEqual(result, "1.0")
 
     def test_read_from_xcode_config(self):
-        result = read_from_plist_or_xcode(
-            plist_key='CFBundleVersion',
-            xcode_key='MARKETING_VERSION',
+        result = read_short_bundle_version(
             info_plist_path='./_tmp/test_config/Test/Info.plist',
             xcode_path='./_tmp/test_config/Test.xcodeproj',
             xcworkspace_path=None,
             scheme=None,
             config=None)
-        self.assertEqual(result, "1")
+        self.assertEqual(result, "1.0")
 
     def test_read_from_workspace_config(self):
-        result = read_from_plist_or_xcode(
-            plist_key='CFBundleVersion',
-            xcode_key='MARKETING_VERSION',
+        result = read_short_bundle_version(
             info_plist_path='./_tmp/test_workspace_config/Test/Info.plist',
-            xcode_path='./_tmp/test_workspace_config/Test.xcodeproj',
-            xcworkspace_path=None,
-            scheme=None,
-            config=None)
-        self.assertEqual(result, "1")
+            xcode_path=None,
+            xcworkspace_path='./_tmp/test_workspace_config/Test.xcworkspace',
+            scheme='Test',
+            config='Config')
+        self.assertEqual(result, "1.0")

--- a/test_read_from_plist_or_xcode.py
+++ b/test_read_from_plist_or_xcode.py
@@ -1,0 +1,49 @@
+from unittest import TestCase
+
+from read_bundle_version import read_from_plist_or_xcode
+
+
+class Test(TestCase):
+    def test_read_from_plist(self):
+        result = read_from_plist_or_xcode(
+            plist_key='CFBundleVersion',
+            xcode_key=None,
+            info_plist_path='./_tmp/test_info_plist/Test/Info.plist',
+            xcode_path=None,
+            xcworkspace_path=None,
+            scheme=None,
+            config=None)
+        self.assertEqual(result, "1")
+
+    def test_read_from_xcode_build_settings(self):
+        result = read_from_plist_or_xcode(
+            plist_key='CFBundleVersion',
+            xcode_key='MARKETING_VERSION',
+            info_plist_path='./_tmp/test_build_settings/Test/Info.plist',
+            xcode_path='./_tmp/test_build_settings/Test.xcodeproj',
+            xcworkspace_path=None,
+            scheme=None,
+            config=None)
+        self.assertEqual(result, "1.0")
+
+    def test_read_from_xcode_config(self):
+        result = read_from_plist_or_xcode(
+            plist_key='CFBundleVersion',
+            xcode_key='MARKETING_VERSION',
+            info_plist_path='./_tmp/test_config/Test/Info.plist',
+            xcode_path='./_tmp/test_config/Test.xcodeproj',
+            xcworkspace_path=None,
+            scheme=None,
+            config=None)
+        self.assertEqual(result, "1")
+
+    def test_read_from_workspace_config(self):
+        result = read_from_plist_or_xcode(
+            plist_key='CFBundleVersion',
+            xcode_key='MARKETING_VERSION',
+            info_plist_path='./_tmp/test_workspace_config/Test/Info.plist',
+            xcode_path='./_tmp/test_workspace_config/Test.xcodeproj',
+            xcworkspace_path=None,
+            scheme=None,
+            config=None)
+        self.assertEqual(result, "1")


### PR DESCRIPTION
This PR adds the configuration option to **update the tag to the latest commit** removing the previous existent one and recreating it again with the same name and latest commit.

**Rationale**
When executing release workflows, there could be the need of having the same version tag getting created with the same name without keeping the previous tag.