### PR TITLE
Update tag option

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -48,6 +48,7 @@ workflows:
             #- bitrise_tag_format: "build__BUILD_"
             #- bitrise_tag_format: "v_VERSION_"
             - use_lightweight_tag: "no"
+            - update_tag: "no"
       - script:
           inputs:
             - content: |

--- a/step.sh
+++ b/step.sh
@@ -24,6 +24,11 @@ fi
 source $THIS_SCRIPT_DIR/format_version_build.sh format $bitrise_tag_format $CFBundleVersion $CFBundleShortVersionString TAG_NAME
 echo "New tag: $TAG_NAME"
 
+if [[ $update_tag == "yes" && $(git tag -l "$TAG_NAME") ]]; then
+  git tag -d "$TAG_NAME"
+  git push --delete origin "$TAG_NAME"
+fi
+
 git tag "$TAG_NAME" "$GIT_CLONE_COMMIT_HASH"
 
 if [[ $use_lightweight_tag == "yes" ]]; then

--- a/step.yml
+++ b/step.yml
@@ -92,6 +92,15 @@ inputs:
       value_options:
         - "no"
         - "yes"
+  - update_tag: "no"
+    opts:
+      category: Config
+      title: "Update tag if already exists?"
+      description: |
+        If yes, the previous tag will be removed and recreated with the latest commit
+      value_options:
+        - "no"
+        - "yes"
 
 outputs:
   - EXAMPLE_STEP_OUTPUT:


### PR DESCRIPTION
This PR adds the configuration option to **update the tag to the latest commit** removing the previous existent one and recreating it again with the same name and latest commit.

### Rationale
When executing release workflows, there could be the need of having the same version tag getting created with the same name without keeping the previous tag.