### PR TITLE
Failing step if git push fail

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# set -ex
+set -e
 
 if [ -z "$bitrise_tag_info_plist_path" ]; then
   echo "bitrise_tag_info_plist_path is empty"


### PR DESCRIPTION
If the `git push` command fails the script should fail and exit to allow the step to fail.
Fixes #25 